### PR TITLE
Add more tests for answer functions

### DIFF
--- a/tests/testthat/test-answer_as_boolean.R
+++ b/tests/testthat/test-answer_as_boolean.R
@@ -1,0 +1,11 @@
+test_that("answer_as_boolean returns boolean", {
+  skip_test_if_no_ollama()
+
+  ollama <- llm_provider_ollama()
+
+  response <- "Is the sky blue?" |>
+    answer_as_boolean() |>
+    send_prompt(ollama, verbose = FALSE)
+
+  expect_true(is.logical(response))
+})

--- a/tests/testthat/test-answer_as_json.R
+++ b/tests/testthat/test-answer_as_json.R
@@ -1,0 +1,11 @@
+test_that("answer_as_json returns valid JSON", {
+  skip_test_if_no_ollama()
+
+  ollama <- llm_provider_ollama()
+
+  response <- "Provide a JSON object with name and age." |>
+    answer_as_json() |>
+    send_prompt(ollama, verbose = FALSE)
+
+  expect_true(jsonlite::validate(response))
+})

--- a/tests/testthat/test-answer_as_key_value.R
+++ b/tests/testthat/test-answer_as_key_value.R
@@ -1,0 +1,13 @@
+test_that("answer_as_key_value returns key-value list", {
+  skip_test_if_no_ollama()
+
+  ollama <- llm_provider_ollama()
+
+  response <- "Provide a list of key-value pairs." |>
+    answer_as_key_value() |>
+    send_prompt(ollama, verbose = FALSE)
+
+  expect_true(is.list(response))
+  expect_true(all(sapply(names(response), is.character)))
+  expect_true(all(sapply(response, is.character)))
+})

--- a/tests/testthat/test-answer_as_list.R
+++ b/tests/testthat/test-answer_as_list.R
@@ -1,0 +1,11 @@
+test_that("answer_as_list returns list", {
+  skip_test_if_no_ollama()
+
+  ollama <- llm_provider_ollama()
+
+  response <- "Provide a list of items." |>
+    answer_as_list() |>
+    send_prompt(ollama, verbose = FALSE)
+
+  expect_true(is.list(response))
+})

--- a/tests/testthat/test-answer_as_named_list.R
+++ b/tests/testthat/test-answer_as_named_list.R
@@ -1,0 +1,12 @@
+test_that("answer_as_named_list returns named list", {
+  skip_test_if_no_ollama()
+
+  ollama <- llm_provider_ollama()
+
+  response <- "Provide a named list with name and age." |>
+    answer_as_named_list(item_names = c("name", "age")) |>
+    send_prompt(ollama, verbose = FALSE)
+
+  expect_true(is.list(response))
+  expect_true(all(c("name", "age") %in% names(response)))
+})

--- a/tests/testthat/test-answer_as_regex_match.R
+++ b/tests/testthat/test-answer_as_regex_match.R
@@ -1,0 +1,12 @@
+test_that("answer_as_regex_match returns matches the regex", {
+  skip_test_if_no_ollama()
+
+  ollama <- llm_provider_ollama()
+
+  response <- "Extract all numbers from this text: 123, 456, and 789." |>
+    answer_as_regex_match("\\d+", mode = "extract_matches") |>
+    send_prompt(ollama, verbose = FALSE)
+
+  expect_true(is.character(response))
+  expect_true(all(grepl("\\d+", response)))
+})

--- a/tests/testthat/test-answer_as_text.R
+++ b/tests/testthat/test-answer_as_text.R
@@ -1,0 +1,13 @@
+test_that("answer_as_text returns constrained text", {
+  skip_test_if_no_ollama()
+
+  ollama <- llm_provider_ollama()
+
+  response <- "Provide a short description of the sky." |>
+    answer_as_text(max_words = 10, max_characters = 50) |>
+    send_prompt(ollama, verbose = FALSE)
+
+  expect_true(is.character(response))
+  expect_true(length(strsplit(response, "\\s+")[[1]]) <= 10)
+  expect_true(nchar(response) <= 50)
+})


### PR DESCRIPTION
Add new tests for various functions in the `tests/testthat` directory.

* **answer_as_boolean**: Add test to check if the response is a boolean.
* **answer_as_json**: Add test to check if the response is a valid JSON.
* **answer_as_key_value**: Add test to check if the response is a key-value list.
* **answer_as_list**: Add test to check if the response is a list.
* **answer_as_named_list**: Add test to check if the response is a named list.
* **answer_as_regex_match**: Add test to check if the response matches the regex.
* **answer_as_text**: Add test to check if the response is a constrained text.

All new tests use the `skip_test_if_no_ollama` function to conditionally skip tests requiring interaction with an LLM provider.

